### PR TITLE
Use of rowspan to assign a group to a lesson

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -14,8 +14,8 @@ from discord.ext import tasks
 import loader
 from models.timetable import Timetable
 from utils import (
-    REST_IMAGES, GROUPS_BY_YEAR, YEAR_OF_STUDY,
-    DISCORD_TOKEN, DISCORD_CHANNEL_ID, LAUNCH_TIME,
+    DISCORD_TOKEN, DISCORD_CHANNEL_ID,
+    REST_IMAGES, LAUNCH_TIME,
     EMOJI_GROUPS, EMBED_COLOR, BLANK_LINE,
     TIME_ZONE, LOCALE, SKIP_WEEKENDS
 )
@@ -31,8 +31,8 @@ def get_tomorrow_date() -> datetime:
     return datetime.now(TIME_ZONE) + timedelta(days=1)
 
 def is_weekend(date: datetime) -> bool:
-            """Check is current date is a weekend."""
-            return date.isoweekday() in [6,7]
+    """Check if date is a weekend day"""
+    return date.isoweekday() in [6,7]
 
 def bold(text: str) -> str:
     """Format a text to be displayed in bold on discord"""
@@ -55,7 +55,7 @@ def generate_embed(timetable: Timetable) -> Embed:
         embed = Embed(title=title, colour=EMBED_COLOR, description=BLANK_LINE)
 
         name = "Groupes"
-        for group in GROUPS_BY_YEAR[YEAR_OF_STUDY]:
+        for group in timetable.groups:
             name += " " + EMOJI_GROUPS.get(group)
 
         embed.add_field(name=name, value=BLANK_LINE, inline=False)
@@ -75,7 +75,7 @@ def generate_embed(timetable: Timetable) -> Embed:
 
         embed = Embed(title=title, colour=EMBED_COLOR, description=BLANK_LINE)
 
-        for group in GROUPS_BY_YEAR[YEAR_OF_STUDY]:
+        for group in timetable.groups:
             # we sort to recover the lessons concerning this group
             group_lessons = []
             for lesson in timetable.lessons:
@@ -95,7 +95,7 @@ def generate_embed(timetable: Timetable) -> Embed:
                 if index != len(group_lessons):
                     value += "\n" + BLANK_LINE
                 # it's the last lesson of the group but it's not the last group -> we add two lines
-                elif group != GROUPS_BY_YEAR[YEAR_OF_STUDY][-1]:
+                elif group != timetable.groups[-1]:
                     value += "\n" + BLANK_LINE + "\n" + BLANK_LINE
 
                 embed.add_field(name=name, value=value, inline=False)
@@ -124,7 +124,7 @@ async def loop():
         tomorrow_date = get_tomorrow_date()
         timetable = loader.get_timetable(tomorrow_date)
 
-        # Skip rest days depends on config
+        # Skip weekends depends on config
         if not timetable.lessons and SKIP_WEEKENDS and is_weekend(tomorrow_date):
             return
 

--- a/src/models/lesson.py
+++ b/src/models/lesson.py
@@ -3,8 +3,7 @@ from enum import Enum
 from datetime import time
 from typing import List
 from utils import (
-    EMOJI_TEACHER, EMOJI_PLACE, EMOJI_LINK,
-    YEAR_OF_STUDY, GROUPS_BY_YEAR
+    EMOJI_TEACHER, EMOJI_PLACE, EMOJI_LINK
 )
 
 class LessonType(Enum):
@@ -36,10 +35,6 @@ class Lesson:
     type: LessonType
     groups: List[str]
     link: str
-
-    def is_a_group_lesson(self) -> bool:
-        """Indicate whether the lesson is common to all groups"""
-        return len(self.groups) == len(GROUPS_BY_YEAR[YEAR_OF_STUDY])
 
     def get_emoji_time(self) -> str:
         """Return the emoji to use for the time according to the start time of the lesson"""

--- a/src/models/timetable.py
+++ b/src/models/timetable.py
@@ -9,10 +9,11 @@ class Timetable:
 
     lessons: List[Lesson]
     date: datetime
+    groups: List[str]
 
     def contains_only_group_lessons(self):
         """Indicate whether all lessons in the timetable are common to all groups"""
         for lesson in self.lessons:
-            if not lesson.is_a_group_lesson():
+            if lesson.groups != self.groups:
                 return False
         return True

--- a/src/utils.py
+++ b/src/utils.py
@@ -48,11 +48,6 @@ REST_IMAGES = [
 #- UTILS
 EMBED_COLOR = 0xff0000
 BLANK_LINE = '\u200b'
-GROUPS_BY_YEAR = {
-    3: ['1', '2', '3', '4'],
-    4: ['1', '2', '3', '4'],
-    5: ['1', '2', '3']
-}
 
 # The structure of the timetable website makes it difficult to recover
 # the duration of a class slot. The following dictionnary contains the


### PR DESCRIPTION
Better approach as TD or TP lessons can concern several groups. Removal of `GROUPS_BY_YEAR` config var as all years have now 4 groups (may require improvement).

Tried to add tests but failed because of `ModuleNotFoundError`, it would be useful to make sure the loader works well on special cases like 4IF 10/10/2022 (one TD for two groups).